### PR TITLE
Support binding multiple routing keys to same exchange

### DIFF
--- a/src/duct/amqp/rabbitmq/langohr/consumers.clj
+++ b/src/duct/amqp/rabbitmq/langohr/consumers.clj
@@ -17,7 +17,8 @@
            (let [ch (lch/open connection)
                  queue (if declare-queue
                          (lq/declare ch queue declare-queue)
-                         queue)]
+                         queue)
+                 handler (lc/ack-unless-exception handler)]
              (when exchange
                (if routing-keys
                  (doseq [routing-key routing-keys]


### PR DESCRIPTION
- automatic acknowledge unless exception is also added, in order to prevent consumer disconnection from RabbitMQ due to acknowledge timeout